### PR TITLE
Improve create_dataset, video_to_slomo

### DIFF
--- a/data/create_dataset.py
+++ b/data/create_dataset.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import os.path
 from shutil import rmtree, move
+import subprocess
 import random
 
 # For parsing commandline arguments
@@ -37,8 +38,9 @@ def extract_frames(videos, inDir, outDir):
 
     for video in videos:
         os.mkdir(os.path.join(outDir, os.path.splitext(video)[0]))
-        retn = os.system('{} -i {} -vf scale={}:{} -vsync 0 -qscale:v 2 {}/%04d.jpg'.format(os.path.join(args.ffmpeg_dir, "ffmpeg"), os.path.join(inDir, video), args.img_width, args.img_height, os.path.join(outDir, os.path.splitext(video)[0])))
-        if retn:
+        try:
+            subprocess.check_call([os.path.join(args.ffmpeg_dir, "ffmpeg"), '-i', os.path.join(inDir, video), '-vf', 'scale={}:{}'.format(args.img_width, args.img_height), '-vsync', '0', '-qscale:v', '2', '{}/%04d.jpg'.format(os.path.join(outDir, os.path.splitext(video)[0]))])
+        except subprocess.CalledProcessError:
             print("Error converting file:{}. Exiting.".format(video))
 
 

--- a/data/create_dataset.py
+++ b/data/create_dataset.py
@@ -39,7 +39,7 @@ def extract_frames(videos, inDir, outDir):
     for video in videos:
         os.mkdir(os.path.join(outDir, os.path.splitext(video)[0]))
         try:
-            subprocess.check_call([os.path.join(args.ffmpeg_dir, "ffmpeg"), '-i', os.path.join(inDir, video), '-vf', 'scale={}:{}'.format(args.img_width, args.img_height), '-vsync', '0', '-qscale:v', '2', '{}/%04d.jpg'.format(os.path.join(outDir, os.path.splitext(video)[0]))])
+            subprocess.check_call([os.path.join(args.ffmpeg_dir, "ffmpeg"), '-i', os.path.join(inDir, video), '-vf', 'scale={}:{}'.format(args.img_width, args.img_height), '-vsync', '0', '-qscale:v', '2', '{}/%09d.jpg'.format(os.path.join(outDir, os.path.splitext(video)[0]))])
         except subprocess.CalledProcessError:
             print("Error converting file:{}. Exiting.".format(video))
 

--- a/video_to_slomo.py
+++ b/video_to_slomo.py
@@ -2,6 +2,7 @@
 import argparse
 import os
 import os.path
+import subprocess
 import ctypes
 from shutil import rmtree, move
 from PIL import Image
@@ -66,21 +67,20 @@ def extract_frames(video, outDir):
     """
 
 
-    error = ""
-    print('{} -i {} -vsync 0 -qscale:v 2 {}/%06d.jpg'.format(os.path.join(args.ffmpeg_dir, "ffmpeg"), video, outDir))
-    retn = os.system('{} -i {} -vsync 0 -qscale:v 2 {}/%06d.jpg'.format(os.path.join(args.ffmpeg_dir, "ffmpeg"), video, outDir))
-    if retn:
-        error = "Error converting file:{}. Exiting.".format(video)
-    return error
+    cmd = [os.path.join(args.ffmpeg_dir, "ffmpeg"), '-i', video, '-vsync', '0', '-qscale:v', '2', '{}/%06d.jpg'.format(outDir)]
+    print(' '.join(cmd))
+    try:
+        subprocess.check_call(cmd)
+    except CalledProcessError:
+        return "Error converting file:{}. Exiting.".format(video)
 
 def create_video(dir):
-    error = ""
-    print('{} -r {} -i {}/%d.jpg -qscale:v 2 {}'.format(os.path.join(args.ffmpeg_dir, "ffmpeg"), args.fps, dir, args.output))
-    retn = os.system('{} -r {} -i {}/%d.jpg -crf 17 -vcodec libx264 {}'.format(os.path.join(args.ffmpeg_dir, "ffmpeg"), args.fps, dir, args.output))
-    if retn:
-        error = "Error creating output video. Exiting."
-    return error
-
+    cmd = [os.path.join(args.ffmpeg_dir, "ffmpeg"), '-r', str(args.fps), '-i', '{}/%d.jpg'.format(dir), '-crf', '17', '-vcodec', 'libx264', args.output]
+    print(' '.join(cmd))
+    try:
+        subprocess.check_call(cmd)
+    except CalledProcessError:
+        return "Error creating output video. Exiting."
 
 def main():
     # Check if arguments are okay


### PR DESCRIPTION
* In both: Use `subprocess.check_call` instead of `os.system`. This means even file names with special characters (e.g. `"`) will work correctly.
* In create_dataset: Increase the number of digits used in frame file names. The previous number would cause frames to appear out of order when using them in training if a video used for the data set had more than 9999 frames.